### PR TITLE
do_shortcode() output buffering fix

### DIFF
--- a/includes/ucf-social-common.php
+++ b/includes/ucf-social-common.php
@@ -94,7 +94,9 @@ if ( ! class_exists( 'UCF_Social_Common' ) ) {
 		 */
 		public static function has_social_feed( $content ) {
 			$has_feed = false;
-			$content_processed = do_shortcode( $content );
+			ob_start();
+			do_shortcode( $content );
+			$content_processed = ob_get_clean();
 
 			// Check against unprocessed string contents for the
 			// [ucf-social-feed] shortcode, as well as processed string


### PR DESCRIPTION
Wrapped `do_shortcode()` call in `UCF_Social_Common::has_social_feed()` within an output buffer to ensure all returned contents are captured/not echoed when called in `ucf_social_enqueued_assets`.