### PR TITLE
Add basic transient flush button to plugin settings page

### DIFF
--- a/includes/ucf-social-common.php
+++ b/includes/ucf-social-common.php
@@ -153,8 +153,8 @@ if ( ! class_exists( 'UCF_Social_Common' ) ) {
 		 * @since 3.0.0
 		 * @return array
 		 */
-		private static function get_social_feed_data() {
-			$transient_name = 'ucf_social_curator_api_data';
+		public static function get_social_feed_data() {
+			$transient_name = UCF_Social_Config::$curator_data_transient;
 			$transient      = get_transient( $transient_name );
 			$result         = array();
 


### PR DESCRIPTION
Adds a pretty rudimentary button to the plugin settings page that flushes transient data for the plugin.  We'll need to remember to click this button whenever we make customization changes to Curator feeds within Curator and want them to appear immediately in embedded widgets.

I'm opening up a separate issue to look into a better means of including the flush success message after the button has been clicked--but for now, this form is otherwise functional and works.

Resolves #21.