### PR TITLE
WP SCIF support + other updates

### DIFF
--- a/includes/ucf-social-config.php
+++ b/includes/ucf-social-config.php
@@ -28,6 +28,62 @@ if ( !class_exists( 'UCF_Social_Config' ) ) {
 			),
 			$curator_data_transient = 'ucf_social_curator_api_data';
 
+		public static function get_social_icon_layouts() {
+			$layouts = array(
+				'default' => 'Default Layout',
+			);
+			$layouts = apply_filters( self::$option_prefix . 'get_social_icon_layouts', $layouts );
+			return $layouts;
+		}
+
+		public static function get_social_icon_colors() {
+			$options = array(
+				'color' => 'Color',
+				'grey'  => 'Grey'
+			);
+			$options = apply_filters( self::$option_prefix . 'get_social_icon_colors', $options );
+			return $options;
+		}
+
+		public static function get_social_icon_sizes() {
+			$options = array(
+				'sm' => 'Small',
+				'md' => 'Medium',
+				'lg' => 'Large'
+			);
+			$options = apply_filters( self::$option_prefix . 'get_social_icon_sizes', $options );
+			return $options;
+		}
+
+		public static function get_social_link_layouts() {
+			$layouts = array(
+				'default' => 'Default Layout',
+			);
+			$layouts = apply_filters( self::$option_prefix . 'get_social_link_layouts', $layouts );
+			return $layouts;
+		}
+
+		public static function get_social_link_sizes() {
+			$options = array(
+				'sm' => 'Small',
+				'md' => 'Medium',
+				'lg' => 'Large'
+			);
+			$options = apply_filters( self::$option_prefix . 'get_social_link_sizes', $options );
+			return $options;
+		}
+
+		public static function get_social_feed_layouts() {
+			$layouts = array(
+				'default'      => 'Default Layout',
+				'scrollbox_sm' => 'Scrollbox - Small',
+				'scrollbox'    => 'Scrollbox - Medium',
+				'scrollbox_lg' => 'Scrollbox - Large'
+			);
+			$layouts = apply_filters( self::$option_prefix . 'get_social_feed_layouts', $layouts );
+			return $layouts;
+		}
+
 		/**
 		 * Creates options via the WP Options API that are utilized by the
 		 * plugin.  Intended to be run on plugin activation.
@@ -603,11 +659,13 @@ if ( !class_exists( 'UCF_Social_Config' ) ) {
 
 	}
 
-	// Register settings and options.
-	add_action( 'admin_init', array( 'UCF_Social_Config', 'settings_init' ) );
-	add_action( 'admin_menu', array( 'UCF_Social_Config', 'add_options_page' ) );
-	add_action( 'admin_post_ucf_social_flush_transient_data', array( 'UCF_Social_Config', 'flush_transient_data' ) );
-
-	// Apply custom formatting to shortcode attributes and options.
-	UCF_Social_Config::add_option_formatting_filters();
 }
+
+
+// Register settings and options.
+add_action( 'admin_init', array( 'UCF_Social_Config', 'settings_init' ) );
+add_action( 'admin_menu', array( 'UCF_Social_Config', 'add_options_page' ) );
+add_action( 'admin_post_ucf_social_flush_transient_data', array( 'UCF_Social_Config', 'flush_transient_data' ) );
+
+// Apply custom formatting to shortcode attributes and options.
+UCF_Social_Config::add_option_formatting_filters();

--- a/includes/ucf-social-shortcodes.php
+++ b/includes/ucf-social-shortcodes.php
@@ -21,6 +21,49 @@ if ( ! class_exists( 'UCF_Social_Shortcode' ) ) {
 			return ob_get_clean();
 		}
 
+		public static function icons_shortcode_interface( $registered_shortcodes ) {
+			if ( class_exists( 'WP_SCIF_Config' ) ) {
+				$fields = array(
+					array(
+						'name'      => 'Layout',
+						'param'     => 'layout',
+						'desc'      => 'The layout to display this list of icons',
+						'type'      => 'select',
+						'options'   => UCF_Social_Config::get_social_icon_layouts(),
+						'default'   => 'default'
+					),
+					array(
+						'name'      => 'Color Scheme',
+						'param'     => 'color',
+						'desc'      => 'The color scheme to apply to the icons.',
+						'type'      => 'select',
+						'options'   => UCF_Social_Config::get_social_icon_colors(),
+						'default'   => 'color'
+					),
+					array(
+						'name'      => 'Size',
+						'param'     => 'size',
+						'desc'      => 'What size each icon should be.',
+						'type'      => 'select',
+						'options'   => UCF_Social_Config::get_social_icon_sizes(),
+						'default'   => 'md'
+					),
+				);
+				$shortcode = array(
+					'command' => 'ucf-social-icons',
+					'name'    => 'UCF Social Icons',
+					'desc'    => 'Displays a list of round social icons that link to social media profiles.',
+					'content' => false,
+					'fields'  => $fields,
+					'preview' => false,
+					'group'   => 'UCF Social'
+				);
+
+				$registered_shortcodes[] = $shortcode;
+				return $registered_shortcodes;
+			}
+		}
+
 		public static function links_shortcode( $atts ) {
 			global $post;
 			$permalink = $share_text = '';
@@ -57,6 +100,88 @@ if ( ! class_exists( 'UCF_Social_Shortcode' ) ) {
 			return ob_get_clean();
 		}
 
+		public static function links_shortcode_interface( $registered_shortcodes ) {
+			if ( class_exists( 'WP_SCIF_Config' ) ) {
+				$fields = array(
+					array(
+						'name'      => 'Layout',
+						'param'     => 'layout',
+						'desc'      => 'The layout to display this list of buttons',
+						'type'      => 'select',
+						'options'   => UCF_Social_Config::get_social_link_layouts(),
+						'default'   => 'default'
+					),
+					array(
+						'name'      => 'Size',
+						'param'     => 'size',
+						'desc'      => 'What size each button should be.',
+						'type'      => 'select',
+						'options'   => UCF_Social_Config::get_social_link_sizes(),
+						'default'   => 'md'
+					),
+					array(
+						'name'      => 'Shareable Permalink',
+						'param'     => 'permalink',
+						'desc'      => 'The link that should be shared when the user clicks a share button. The current page/post will be used by default.',
+						'type'      => 'text'
+					),
+					array(
+						'name'      => 'Share Text',
+						'param'     => 'share_text',
+						'desc'      => 'Text that should be included in shared tweets and emails with the permalink. The current page/post title will be used by default.',
+						'type'      => 'text'
+					),
+					array(
+						'name'      => 'Include Facebook',
+						'param'     => 'facebook',
+						'desc'      => 'Whether Facebook should be included in the list of share buttons.',
+						'type'      => 'checkbox',
+						'default'   => UCF_Social_Config::get_option_or_default( 'include_facebook_sharing' )
+					),
+					array(
+						'name'      => 'Include Twitter',
+						'param'     => 'twitter',
+						'desc'      => 'Whether Twitter should be included in the list of share buttons.',
+						'type'      => 'checkbox',
+						'default'   => UCF_Social_Config::get_option_or_default( 'include_twitter_sharing' )
+					),
+					array(
+						'name'      => 'Include Google+',
+						'param'     => 'google',
+						'desc'      => 'Whether Google+ should be included in the list of share buttons.',
+						'type'      => 'checkbox',
+						'default'   => UCF_Social_Config::get_option_or_default( 'include_google_sharing' )
+					),
+					array(
+						'name'      => 'Include LinkedIn',
+						'param'     => 'linkedin',
+						'desc'      => 'Whether LinkedIn should be included in the list of share buttons.',
+						'type'      => 'checkbox',
+						'default'   => UCF_Social_Config::get_option_or_default( 'include_linkedin_sharing' )
+					),
+					array(
+						'name'      => 'Include Email',
+						'param'     => 'email',
+						'desc'      => 'Whether Email should be included in the list of share buttons.',
+						'type'      => 'checkbox',
+						'default'   => UCF_Social_Config::get_option_or_default( 'include_email_sharing' )
+					),
+				);
+				$shortcode = array(
+					'command' => 'ucf-social-links',
+					'name'    => 'UCF Social Links',
+					'desc'    => 'Displays a list of social sharing buttons (like/share/tweet)',
+					'content' => false,
+					'fields'  => $fields,
+					'preview' => false,
+					'group'   => 'UCF Social'
+				);
+
+				$registered_shortcodes[] = $shortcode;
+				return $registered_shortcodes;
+			}
+		}
+
 		public static function feed_shortcode( $atts ) {
 			$atts = shortcode_atts( array(
 				'feed'         => UCF_Social_Config::get_option_or_default( 'curator_default_feed' ), // feed ID
@@ -84,9 +209,69 @@ if ( ! class_exists( 'UCF_Social_Shortcode' ) ) {
 			echo UCF_Social_Common::display_social_feed( $atts );
 			return ob_get_clean();
 		}
+
+		public static function feed_shortcode_interface( $registered_shortcodes ) {
+			if ( class_exists( 'WP_SCIF_Config' ) ) {
+				$fields = array(
+					array(
+						'name'      => 'Feed ID',
+						'param'     => 'feed',
+						'desc'      => 'Specify a unique feed to display by its ID.',
+						'type'      => 'text',
+						'default'   => UCF_Social_Config::get_option_or_default( 'curator_default_feed' )
+					),
+					array(
+						'name'      => 'Layout',
+						'param'     => 'layout',
+						'desc'      => 'The layout to display this social feed',
+						'type'      => 'select',
+						'options'   => UCF_Social_Config::get_social_feed_layouts(),
+						'default'   => 'default'
+					),
+					array(
+						'name'      => 'Type',
+						'param'     => 'type',
+						'desc'      => 'Overrides the <a href="https://github.com/curatorio/widgets#widgets" target="_blank">type of widget</a> to use for this feed.',
+						'type'      => 'text'
+					),
+					array(
+						'name'      => 'CSS Class(es)',
+						'param'     => 'class',
+						'desc'      => 'CSS classes to be applied to the wrapper element surrounding the widget.',
+						'type'      => 'text'
+					),
+					array(
+						'name'      => 'Container ID',
+						'param'     => 'container',
+						'desc'      => 'ID to apply to the widget\'s container element. Must be unique. Defaults to a randomized value.',
+						'type'      => 'text'
+					),
+					array(
+						'name'      => 'Options File',
+						'param'     => 'options_file',
+						'desc'      => 'Either an attachment ID or direct URL that points to a JSON file containing widget configuration overrides. See <a href="https://github.com/curatorio/widgets#customisation" target="_blank">Curator\'s widget documentation</a> for available options. The JSON file should contain only the options object.',
+						'type'      => 'text'
+					),
+				);
+				$shortcode = array(
+					'command' => 'ucf-social-feed',
+					'name'    => 'UCF Social Feed',
+					'desc'    => 'Displays a Curator.io social feed widget.',
+					'content' => false,
+					'fields'  => $fields,
+					'preview' => false,
+					'group'   => 'UCF Social'
+				);
+
+				$registered_shortcodes[] = $shortcode;
+				return $registered_shortcodes;
+			}
+		}
 	}
 
-	add_shortcode( 'ucf-social-icons', array( 'UCF_Social_Shortcode', 'icons_shortcode' ) );
-	add_shortcode( 'ucf-social-links', array( 'UCF_Social_Shortcode', 'links_shortcode' ) );
-	add_shortcode( 'ucf-social-feed', array( 'UCF_Social_Shortcode', 'feed_shortcode' ) );
 }
+
+// Register shortcodes and shortcode interface options
+add_shortcode( 'ucf-social-icons', array( 'UCF_Social_Shortcode', 'icons_shortcode' ) );
+add_shortcode( 'ucf-social-links', array( 'UCF_Social_Shortcode', 'links_shortcode' ) );
+add_shortcode( 'ucf-social-feed', array( 'UCF_Social_Shortcode', 'feed_shortcode' ) );

--- a/ucf-social.php
+++ b/ucf-social.php
@@ -12,27 +12,49 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
+define( 'UCF_SOCIAL__PLUGIN_FILE', __FILE__ );
+
+
+// Layouts - social feed
+require_once 'layouts/social-feed/default.php';
+require_once 'layouts/social-feed/scrollbox.php';
+require_once 'layouts/social-feed/scrollbox_sm.php';
+require_once 'layouts/social-feed/scrollbox_lg.php';
+
+// Layouts - social icons
+require_once 'layouts/social-icons/default.php';
+
+// Layouts - social links
+require_once 'layouts/social-links/default.php';
+
+// Core plugin files
+require_once 'includes/ucf-social-config.php';
+require_once 'includes/ucf-social-common.php';
+require_once 'includes/ucf-social-shortcodes.php';
+
+
+if ( ! function_exists( 'ucf_social_activate' ) ) {
+	function ucf_social_activate() {
+		UCF_Social_Config::add_options();
+	}
+}
+
+if ( ! function_exists( 'ucf_social_deactivate' ) ) {
+	function ucf_social_deactivate() {
+		UCF_Social_Config::delete_options();
+	}
+}
+
+register_activation_hook( UCF_SOCIAL__PLUGIN_FILE, 'ucf_social_activate' );
+register_deactivation_hook( UCF_SOCIAL__PLUGIN_FILE, 'ucf_social_deactivate' );
+
+
 add_action( 'plugins_loaded', function() {
 
-	define( 'UCF_SOCIAL__PLUGIN_FILE', __FILE__ );
-
-	// Layouts - social feed
-	require_once 'layouts/social-feed/default.php';
-	require_once 'layouts/social-feed/scrollbox.php';
-	require_once 'layouts/social-feed/scrollbox_sm.php';
-	require_once 'layouts/social-feed/scrollbox_lg.php';
-
-	// Layouts - social icons
-	require_once 'layouts/social-icons/default.php';
-
-	// Layouts - social links
-	require_once 'layouts/social-links/default.php';
-
-	// Core plugin files
-	require_once 'includes/ucf-social-config.php';
-	require_once 'includes/ucf-social-common.php';
-	require_once 'includes/ucf-social-shortcodes.php';
+	if ( class_exists( 'WP_SCIF_Config' ) ) {
+		add_filter( 'wp_scif_add_shortcode', array( 'UCF_Social_Shortcode', 'icons_shortcode_interface' ), 10, 1 );
+		add_filter( 'wp_scif_add_shortcode', array( 'UCF_Social_Shortcode', 'links_shortcode_interface' ), 10, 1 );
+		add_filter( 'wp_scif_add_shortcode', array( 'UCF_Social_Shortcode', 'feed_shortcode_interface' ), 10, 1 );
+	}
 
 } );
-
-?>


### PR DESCRIPTION
- Adds basic WP SCIF support for all 3 shortcodes
- Layouts, colors and sizes are now overrideable via filters for shortcodes that support those params
- Added missing plugin activation/deactivation actions
- Moved most file includes and other functions out of the `plugins_loaded` hook

Resolves #20 