### PR TITLE
Fixed undefined index notice on scrollbox layouts

### DIFF
--- a/layouts/social-feed/scrollbox.php
+++ b/layouts/social-feed/scrollbox.php
@@ -10,7 +10,7 @@ if ( ! function_exists( 'ucf_social_feed_display_scrollbox_before' ) ) {
 	function ucf_social_feed_display_scrollbox_before( $content='', $atts ) {
 		ob_start();
 	?>
-		<aside class="ucf-social-feed ucf-social-feed-scrollbox ucf-social-feed-scrollbox-md <?php echo $atts['class']; ?>" id="<?php echo $atts['id']; ?>">
+		<aside class="ucf-social-feed ucf-social-feed-scrollbox ucf-social-feed-scrollbox-md <?php echo $atts['class']; ?>" id="<?php echo $atts['container']; ?>">
 	<?php
 		return ob_get_clean();
 	}

--- a/layouts/social-feed/scrollbox_lg.php
+++ b/layouts/social-feed/scrollbox_lg.php
@@ -10,7 +10,7 @@ if ( ! function_exists( 'ucf_social_feed_display_scrollbox_lg_before' ) ) {
 	function ucf_social_feed_display_scrollbox_lg_before( $content='', $atts ) {
 		ob_start();
 	?>
-		<aside class="ucf-social-feed ucf-social-feed-scrollbox ucf-social-feed-scrollbox-lg <?php echo $atts['class']; ?>" id="<?php echo $atts['id']; ?>">
+		<aside class="ucf-social-feed ucf-social-feed-scrollbox ucf-social-feed-scrollbox-lg <?php echo $atts['class']; ?>" id="<?php echo $atts['container']; ?>">
 	<?php
 		return ob_get_clean();
 	}

--- a/layouts/social-feed/scrollbox_sm.php
+++ b/layouts/social-feed/scrollbox_sm.php
@@ -10,7 +10,7 @@ if ( ! function_exists( 'ucf_social_feed_display_scrollbox_sm_before' ) ) {
 	function ucf_social_feed_display_scrollbox_sm_before( $content='', $atts ) {
 		ob_start();
 	?>
-		<aside class="ucf-social-feed ucf-social-feed-scrollbox ucf-social-feed-scrollbox-sm <?php echo $atts['class']; ?>" id="<?php echo $atts['id']; ?>">
+		<aside class="ucf-social-feed ucf-social-feed-scrollbox ucf-social-feed-scrollbox-sm <?php echo $atts['class']; ?>" id="<?php echo $atts['container']; ?>">
 	<?php
 		return ob_get_clean();
 	}


### PR DESCRIPTION
The shortcode attribute for defining an ID on the wrapper element of a social feed is `container` (not `id`); this update fixes where `id` is incorrectly used.